### PR TITLE
feat: enhance user experience by letting frontend decide which page t…

### DIFF
--- a/state_handler/state_handler.go
+++ b/state_handler/state_handler.go
@@ -88,10 +88,10 @@ func (sh DefaultStateHandler) Generate(cookieStore *sessions.CookieStore, w http
 
 	// retrieve redirect url from query in order to let frontend decide where to redirect
 	q := r.URL.Query()
-	redirectUrl := q.Get(continueParam)
+	continueArg := q.Get(continueParam)
 	var err error
-	if redirectUrl != "" {
-		continueURI = redirectUrl
+	if continueArg != "" {
+		continueURI = continueArg
 	}
 
 	// generate nonce

--- a/state_handler/state_handler.go
+++ b/state_handler/state_handler.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	nonceSize = int(16)
+	nonceSize     = int(16)
+	redirectParam = "redirect_url"
 )
 
 var (
@@ -83,6 +84,14 @@ func (sh DefaultStateHandler) Generate(cookieStore *sessions.CookieStore, w http
 	continueURI := sh.ContinueURI
 	if continueURI == "" {
 		continueURI = r.RequestURI
+	}
+
+	// retrieve redirect url from query in order to let frontend decide where to redirect
+	q := r.URL.Query()
+	redirectUrl := q.Get(redirectParam)
+	var err error
+	if redirectUrl != "" {
+		continueURI = redirectUrl
 	}
 
 	// generate nonce

--- a/state_handler/state_handler.go
+++ b/state_handler/state_handler.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	nonceSize     = int(16)
-	redirectParam = "redirect_url"
+	continueParam = "continue_url"
 )
 
 var (
@@ -88,7 +88,7 @@ func (sh DefaultStateHandler) Generate(cookieStore *sessions.CookieStore, w http
 
 	// retrieve redirect url from query in order to let frontend decide where to redirect
 	q := r.URL.Query()
-	redirectUrl := q.Get(redirectParam)
+	redirectUrl := q.Get(continueParam)
 	var err error
 	if redirectUrl != "" {
 		continueURI = redirectUrl


### PR DESCRIPTION
To enhance the user experience when a user's token has expired and they need to re-login, we should redirect them to their current page instead of the root page. Allowing the front-end to determine the appropriate page to redirect to after authentication will ensure a smoother and more seamless user experience.

To achieve this, we will attempt to get the redirect query string from the request. If it exists, we will use it instead of the continueURI from the config.